### PR TITLE
Added source directory arg to `export` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ The `serve` command is the default command. Running `tailwind-config-viewer` is 
 
 ### export
 
-Exports the viewer to a directory that can be uploaded to a static host. It accepts the output directory path as its sole argument. 
+Exports the viewer to a directory that can be uploaded to a static host. It accepts both the src and output directories path as arguments. 
 
-`tailwind-config-viewer export ./output-dir`
+`tailwind-config-viewer export ./source-dir ./output-dir`
 
-If an output directory isn't specificied it will be output to `tcv-build`.
+If a `source directory` isn't specificied it will use `dist`.
+If an `output directory` isn't specificied it will be output to `tcv-build`.
 
 **Options**
 

--- a/cli/export.js
+++ b/cli/export.js
@@ -4,7 +4,7 @@ const crypto = require('crypto')
 const replace = require('replace-in-file')
 const { resolveConfigToJson } = require('../lib/tailwindConfigUtils')
 
-module.exports = function (outputDir, config) {
+module.exports = function (srcDir, outputDir, config) {
   outputDir = path.resolve(process.cwd(), outputDir)
 
   fs.removeSync(outputDir)
@@ -15,7 +15,7 @@ module.exports = function (outputDir, config) {
 
   fs.writeFileSync(path.resolve(outputDir, configFileName), configJson)
 
-  fs.copySync('./dist', outputDir)
+  fs.copySync(srcDir, outputDir)
 
   replace.sync({
     files: `${outputDir}/index.html`,

--- a/cli/index.js
+++ b/cli/index.js
@@ -18,10 +18,10 @@ program
   })
 
 program
-  .command('export [outputDir]')
+  .command('export [srcDir] [outputDir]')
   .description('Create a static export of the viewer')
-  .action((outputDir = './tcv-build') => {
-    require('./export')(outputDir, program.config)
+  .action((srcDir = './dist', outputDir = './tcv-build') => {
+    require('./export')(srcDir, outputDir, program.config)
   })
 
 program.parse(process.argv)


### PR DESCRIPTION
This PR adds a `source directory` argument to the `export` command. If a `source directory` isn't specified it will use `dist` as default