### PR TITLE
Move core-js to a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,7 @@
         "koa-static": "^5.0.0",
         "open": "^7.0.4",
         "portfinder": "^1.0.26",
-        "replace-in-file": "^6.1.0",
-        "vue": "^2.6.10",
-        "vue-draggable-resizable": "^2.2.0"
+        "replace-in-file": "^6.1.0"
       },
       "bin": {
         "tailwind-config-viewer": "cli/index.js",
@@ -36,6 +34,8 @@
         "sass-loader": "^9.0.3",
         "tailwindcss": "^1.4.4",
         "tailwindcss-dark-mode": "^1.1.6",
+        "vue": "^2.6.10",
+        "vue-draggable-resizable": "^2.2.0",
         "vue-template-compiler": "^2.5.21"
       },
       "engines": {
@@ -14679,12 +14679,14 @@
     "node_modules/vue": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
-      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
+      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
+      "dev": true
     },
     "node_modules/vue-draggable-resizable": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/vue-draggable-resizable/-/vue-draggable-resizable-2.2.0.tgz",
       "integrity": "sha512-KjVyzg0OtLsyVhnwD/6NozJkLMD3li41QB/aJIJUr3VS75Gn32UPOWidLvhwsbkwNQcKajXW9QCV1aTrN6MY8w==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0",
         "npm": ">= 3.0.0"
@@ -27988,12 +27990,14 @@
     "vue": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
-      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
+      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
+      "dev": true
     },
     "vue-draggable-resizable": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/vue-draggable-resizable/-/vue-draggable-resizable-2.2.0.tgz",
-      "integrity": "sha512-KjVyzg0OtLsyVhnwD/6NozJkLMD3li41QB/aJIJUr3VS75Gn32UPOWidLvhwsbkwNQcKajXW9QCV1aTrN6MY8w=="
+      "integrity": "sha512-KjVyzg0OtLsyVhnwD/6NozJkLMD3li41QB/aJIJUr3VS75Gn32UPOWidLvhwsbkwNQcKajXW9QCV1aTrN6MY8w==",
+      "dev": true
     },
     "vue-eslint-parser": {
       "version": "2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@koa/router": "^9.0.1",
         "commander": "^6.0.0",
-        "core-js": "^2.6.5",
         "fs-extra": "^9.0.1",
         "koa": "^2.12.0",
         "koa-static": "^5.0.0",
@@ -30,6 +29,7 @@
         "@vue/cli-service": "^3.7.0",
         "@vue/eslint-config-standard": "^4.0.0",
         "babel-eslint": "^10.0.1",
+        "core-js": "^2.6.5",
         "eslint": "^5.16.0",
         "eslint-plugin-vue": "^5.0.0",
         "sass": "^1.26.10",
@@ -3741,7 +3741,8 @@
     "node_modules/core-js": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.8.tgz",
-      "integrity": "sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg=="
+      "integrity": "sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg==",
+      "dev": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -18865,7 +18866,8 @@
     "core-js": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.8.tgz",
-      "integrity": "sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg=="
+      "integrity": "sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@koa/router": "^9.0.1",
     "commander": "^6.0.0",
-    "core-js": "^2.6.5",
     "fs-extra": "^9.0.1",
     "koa": "^2.12.0",
     "koa-static": "^5.0.0",
@@ -56,6 +55,7 @@
     "@vue/cli-service": "^3.7.0",
     "@vue/eslint-config-standard": "^4.0.0",
     "babel-eslint": "^10.0.1",
+    "core-js": "^2.6.5",
     "eslint": "^5.16.0",
     "eslint-plugin-vue": "^5.0.0",
     "sass": "^1.26.10",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,7 @@
     "koa-static": "^5.0.0",
     "open": "^7.0.4",
     "portfinder": "^1.0.26",
-    "replace-in-file": "^6.1.0",
-    "vue": "^2.6.10",
-    "vue-draggable-resizable": "^2.2.0"
+    "replace-in-file": "^6.1.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.7.0",
@@ -62,6 +60,8 @@
     "sass-loader": "^9.0.3",
     "tailwindcss": "^1.4.4",
     "tailwindcss-dark-mode": "^1.1.6",
+    "vue": "^2.6.10",
+    "vue-draggable-resizable": "^2.2.0",
     "vue-template-compiler": "^2.5.21"
   }
 }


### PR DESCRIPTION
core-js is only used when building and isn't directly used by the
project, so don't require users of the built version to install it.