### PR TITLE
add: support for changing typography example

### DIFF
--- a/src/components/Canvas/Sections/FontSizes.vue
+++ b/src/components/Canvas/Sections/FontSizes.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="space-y-6">
     <div
-      v-for="(value, prop) in data"
+      v-for="(value, prop) in data.fontSize"
       :key="prop"
     >
       <p
@@ -10,7 +10,7 @@
           fontSize: value
         }"
       >
-        The quick brown fox jumped over the lazy dog.
+        {{ data.typographyExample || 'The quick brown fox jumped over the lazy dog.' }}
       </p>
       <CanvasBlockLabel
         :label="`text-${prop}`"

--- a/src/components/Canvas/Sections/FontSizes.vue
+++ b/src/components/Canvas/Sections/FontSizes.vue
@@ -10,7 +10,7 @@
           fontSize: value
         }"
       >
-        {{ data.typographyExample || 'The quick brown fox jumped over the lazy dog.' }}
+        {{ data.typographyExample }}
       </p>
       <CanvasBlockLabel
         :label="`text-${prop}`"

--- a/src/components/Canvas/Sections/FontWeight.vue
+++ b/src/components/Canvas/Sections/FontWeight.vue
@@ -10,7 +10,7 @@
           fontWeight: value
         }"
       >
-        {{ data.typographyExample || 'The quick brown fox jumped over the lazy dog.' }}
+        {{ data.typographyExample }}
       </p>
       <CanvasBlockLabel
         :label="`font-${prop}`"

--- a/src/components/Canvas/Sections/FontWeight.vue
+++ b/src/components/Canvas/Sections/FontWeight.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="space-y-6">
     <div
-      v-for="(value, prop) in data"
+      v-for="(value, prop) in data.fontWeight"
       :key="prop"
     >
       <p
@@ -10,7 +10,7 @@
           fontWeight: value
         }"
       >
-        The quick brown fox jumped over the lazy dog.
+        {{ data.typographyExample || 'The quick brown fox jumped over the lazy dog.' }}
       </p>
       <CanvasBlockLabel
         :label="`font-${prop}`"

--- a/src/components/Canvas/Sections/LetterSpacing.vue
+++ b/src/components/Canvas/Sections/LetterSpacing.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="space-y-6">
     <div
-      v-for="(value, prop) in data"
+      v-for="(value, prop) in data.letterSpacing"
       :key="prop"
     >
       <p
@@ -10,7 +10,7 @@
           letterSpacing: value
         }"
       >
-        The quick brown fox jumped over the lazy dog.
+        {{ data.typographyExample || 'The quick brown fox jumped over the lazy dog.' }}
       </p>
       <CanvasBlockLabel
         :label="`tracking-${prop}`"

--- a/src/components/Canvas/Sections/LetterSpacing.vue
+++ b/src/components/Canvas/Sections/LetterSpacing.vue
@@ -10,7 +10,7 @@
           letterSpacing: value
         }"
       >
-        {{ data.typographyExample || 'The quick brown fox jumped over the lazy dog.' }}
+        {{ data.typographyExample }}
       </p>
       <CanvasBlockLabel
         :label="`tracking-${prop}`"

--- a/src/components/Canvas/Sections/LineHeight.vue
+++ b/src/components/Canvas/Sections/LineHeight.vue
@@ -10,8 +10,8 @@
           lineHeight: value
         }"
       >
-        <p>{{ data.typographyExample || 'The quick brown fox jumped over the lazy dog.' }}</p>
-        <p>{{ data.typographyExample || 'The quick brown fox jumped over the lazy dog.' }}</p>
+        <p>{{ data.typographyExample }}</p>
+        <p>{{ data.typographyExample }}</p>
       </div>
       <CanvasBlockLabel
         :label="`leading-${prop}`"

--- a/src/components/Canvas/Sections/LineHeight.vue
+++ b/src/components/Canvas/Sections/LineHeight.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="space-y-6">
     <div
-      v-for="(value, prop) in data"
+      v-for="(value, prop) in data.lineHeight"
       :key="prop"
     >
       <div
@@ -10,8 +10,8 @@
           lineHeight: value
         }"
       >
-        <p>The quick brown fox jumped over the lazy dog.</p>
-        <p>The quick brown fox jumped over the lazy dog.</p>
+        <p>{{ data.typographyExample || 'The quick brown fox jumped over the lazy dog.' }}</p>
+        <p>{{ data.typographyExample || 'The quick brown fox jumped over the lazy dog.' }}</p>
       </div>
       <CanvasBlockLabel
         :label="`leading-${prop}`"

--- a/src/components/Canvas/themeComponentMapper.js
+++ b/src/components/Canvas/themeComponentMapper.js
@@ -22,7 +22,7 @@ export default function themeComponentMapper (theme) {
       title: 'Font Sizes',
       data: {
         fontSize: theme.fontSize,
-        typographyExample: addIfThemePropExists(theme.configViewer, () => true) && theme.configViewer.typographyExample
+        typographyExample: theme.configViewer.typographyExample
       }
     },
     {
@@ -30,7 +30,7 @@ export default function themeComponentMapper (theme) {
       title: 'Font Weight',
       data: {
         fontWeight: theme.fontWeight,
-        typographyExample: addIfThemePropExists(theme.configViewer, () => true) && theme.configViewer.typographyExample
+        typographyExample: theme.configViewer.typographyExample
       }
     },
     {
@@ -38,7 +38,7 @@ export default function themeComponentMapper (theme) {
       title: 'Letter Spacing',
       data: {
         letterSpacing: theme.letterSpacing,
-        typographyExample: addIfThemePropExists(theme.configViewer, () => true) && theme.configViewer.typographyExample
+        typographyExample: theme.configViewer.typographyExample
       }
     },
     {
@@ -46,7 +46,7 @@ export default function themeComponentMapper (theme) {
       title: 'Line Height',
       data: {
         lineHeight: theme.lineHeight,
-        typographyExample: addIfThemePropExists(theme.configViewer, () => true) && theme.configViewer.typographyExample
+        typographyExample: theme.configViewer.typographyExample
       }
     },
     {

--- a/src/components/Canvas/themeComponentMapper.js
+++ b/src/components/Canvas/themeComponentMapper.js
@@ -20,22 +20,34 @@ export default function themeComponentMapper (theme) {
     {
       component: 'FontSizes',
       title: 'Font Sizes',
-      data: theme.fontSize
+      data: {
+        fontSize: theme.fontSize,
+        typographyExample: addIfThemePropExists(theme.configViewer, () => true) && theme.configViewer.typographyExample
+      }
     },
     {
       component: 'FontWeight',
       title: 'Font Weight',
-      data: theme.fontWeight
+      data: {
+        fontWeight: theme.fontWeight,
+        typographyExample: addIfThemePropExists(theme.configViewer, () => true) && theme.configViewer.typographyExample
+      }
     },
     {
       component: 'LetterSpacing',
       title: 'Letter Spacing',
-      data: theme.letterSpacing
+      data: {
+        letterSpacing: theme.letterSpacing,
+        typographyExample: addIfThemePropExists(theme.configViewer, () => true) && theme.configViewer.typographyExample
+      }
     },
     {
       component: 'LineHeight',
       title: 'Line Height',
-      data: theme.lineHeight
+      data: {
+        lineHeight: theme.lineHeight,
+        typographyExample: addIfThemePropExists(theme.configViewer, () => true) && theme.configViewer.typographyExample
+      }
     },
     {
       component: 'Screens',

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -1,7 +1,8 @@
 export default {
   theme: {
     configViewer: {
-      baseFontSize: 16
+      baseFontSize: 16,
+      typographyExample: 'The quick brown fox jumped over the lazy dog.'
     }
   }
 }


### PR DESCRIPTION
issue: #24 

Added support for changing typography example.

`theme.configViewer.typographyExample` is referenced, and if not, the previous example text will be displayed.
