### PR TITLE
Fix stickyEvents eslint warning (#33)

### DIFF
--- a/src/lib/stickyEvents.js
+++ b/src/lib/stickyEvents.js
@@ -66,6 +66,7 @@ export default class StickyEvents {
 
   enableEvents () {
     if (window.self !== window.top) {
+      // eslint-disable-next-line
       console.warn('StickyEvents: There are issues with using IntersectionObservers in an iframe, canceling initialization. Please see https://github.com/w3c/IntersectionObserver/issues/183')
 
       return


### PR DESCRIPTION
Fixes #33 

stickyEvents has an eslint `no-console` warning. This PR makes a quick fix, disabling eslint warnings for that line. Don't know if this is the way you want to address #33 or not.