### PR TITLE
a11y: improve color contrast (#35)

### DIFF
--- a/src/components/Canvas/Canvas.vue
+++ b/src/components/Canvas/Canvas.vue
@@ -21,8 +21,8 @@
               v-for="section in configTransformed"
               :key="section.title"
               :href="`#${section.title}`"
-              class="relative flex items-center py-2 hover:text-gray-800 dark-hover:text-gray-200 text-base rounded-sm"
-              :class="[activeSection === section ? 'text-gray-800 dark:text-gray-200' : 'text-gray-600 dark:text-gray-500']"
+              class="relative flex items-center py-2 hover:text-gray-900 dark-hover:text-gray-200 text-base rounded-sm"
+              :class="[activeSection === section ? 'text-gray-900 dark:text-gray-200' : 'text-gray-700 dark:text-gray-500']"
               @click="setActiveSection(section)"
             >
               <div

--- a/src/components/Canvas/CanvasBlockLabel.vue
+++ b/src/components/Canvas/CanvasBlockLabel.vue
@@ -38,7 +38,7 @@
     >
       {{ prefixClassName(label) }}
     </div>
-    <div v-if="value" class="text-sm text-gray-600 dark:text-gray-500 break-words">
+    <div v-if="value" class="text-sm text-gray-700 dark:text-gray-500 break-words">
       {{ displayValue }}
     </div>
   </div>

--- a/src/components/Canvas/CanvasSectionRow.vue
+++ b/src/components/Canvas/CanvasSectionRow.vue
@@ -21,7 +21,7 @@ export default {
 
   data () {
     return {
-      blockClasses: 'bg-gray-400 dark:bg-gray-700 h-28'
+      blockClasses: 'bg-gray-600 dark:bg-gray-700 h-28'
     }
   }
 }

--- a/src/components/Canvas/CanvasSectionRow.vue
+++ b/src/components/Canvas/CanvasSectionRow.vue
@@ -21,7 +21,7 @@ export default {
 
   data () {
     return {
-      blockClasses: 'bg-gray-600 dark:bg-gray-700 h-28'
+      blockClasses: 'bg-gray-500 dark:bg-gray-700 h-28'
     }
   }
 }

--- a/src/components/Canvas/Sections/BorderRadius.vue
+++ b/src/components/Canvas/Sections/BorderRadius.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-wrap -mb-4">
     <div v-for="(value, prop) in data" :key="prop" class="w-full md:w-36 md:mr-4 mb-4">
       <div
-        class="bg-gray-400 dark:bg-gray-700 mb-2 md:w-36 h-36"
+        class="bg-gray-600 dark:bg-gray-700 mb-2 md:w-36 h-36"
         :style="{
           borderRadius: value
         }"

--- a/src/components/Canvas/Sections/BorderRadius.vue
+++ b/src/components/Canvas/Sections/BorderRadius.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-wrap -mb-4">
     <div v-for="(value, prop) in data" :key="prop" class="w-full md:w-36 md:mr-4 mb-4">
       <div
-        class="bg-gray-600 dark:bg-gray-700 mb-2 md:w-36 h-36"
+        class="bg-gray-500 dark:bg-gray-700 mb-2 md:w-36 h-36"
         :style="{
           borderRadius: value
         }"

--- a/src/components/Canvas/Sections/BorderWidth.vue
+++ b/src/components/Canvas/Sections/BorderWidth.vue
@@ -6,7 +6,7 @@
       class="w-full md:w-36 md:mr-4 mb-4"
     >
       <div
-        class="mb-2 h-36 bg-gray-200 dark:bg-gray-800 border-gray-600 dark:border-gray-700"
+        class="mb-2 h-36 bg-gray-200 dark:bg-gray-800 border-gray-500 dark:border-gray-700"
         :style="{
           borderWidth: value
         }"

--- a/src/components/Canvas/Sections/BorderWidth.vue
+++ b/src/components/Canvas/Sections/BorderWidth.vue
@@ -6,7 +6,7 @@
       class="w-full md:w-36 md:mr-4 mb-4"
     >
       <div
-        class="mb-2 h-36 bg-gray-200 dark:bg-gray-800 border-gray-400 dark:border-gray-700"
+        class="mb-2 h-36 bg-gray-200 dark:bg-gray-800 border-gray-600 dark:border-gray-700"
         :style="{
           borderWidth: value
         }"

--- a/src/components/Canvas/Sections/Opacity.vue
+++ b/src/components/Canvas/Sections/Opacity.vue
@@ -6,7 +6,7 @@
       class="w-full md:w-36 md:mr-4 mb-4"
     >
       <div
-        class="mb-2 bg-gray-600 dark:bg-gray-700 w-full md:w-36 h-36"
+        class="mb-2 bg-gray-500 dark:bg-gray-700 w-full md:w-36 h-36"
         :style="{
           opacity: value
         }"

--- a/src/components/Canvas/Sections/Opacity.vue
+++ b/src/components/Canvas/Sections/Opacity.vue
@@ -6,7 +6,7 @@
       class="w-full md:w-36 md:mr-4 mb-4"
     >
       <div
-        class="mb-2 bg-gray-400 dark:bg-gray-700 w-full md:w-36 h-36"
+        class="mb-2 bg-gray-600 dark:bg-gray-700 w-full md:w-36 h-36"
         :style="{
           opacity: value
         }"

--- a/src/components/Canvas/Sections/Spacing.vue
+++ b/src/components/Canvas/Sections/Spacing.vue
@@ -32,7 +32,7 @@
         :key="prop"
       >
         <div
-          class="mb-2 bg-gray-400 dark:bg-gray-700"
+          class="mb-2 bg-gray-600 dark:bg-gray-700"
           :style="{
             width: value,
             height: value,

--- a/src/components/Canvas/Sections/Spacing.vue
+++ b/src/components/Canvas/Sections/Spacing.vue
@@ -32,7 +32,7 @@
         :key="prop"
       >
         <div
-          class="mb-2 bg-gray-600 dark:bg-gray-700"
+          class="mb-2 bg-gray-500 dark:bg-gray-700"
           :style="{
             width: value,
             height: value,


### PR DESCRIPTION
Resolves #35 

Increases color contrast in light mode (it's already okay in dark mode, I believe based on a fairly quick check).

Did this for my own use and figured I'd share it. It does change the aesthetic so don't know if it's the right solution for you. I did not do a serious a11y audit or anything like that so I don't promise full WCAG compliance. But the things the things that jumped out to me —nav, keys, borders, and blocks— are now addressed. If you don't use it hopefully it's useful as a reference for what lines would change for #35.

before|after
---|---
![image](https://user-images.githubusercontent.com/3282350/111076619-6c931600-84c3-11eb-848b-0cd266d686c9.png)|![image](https://user-images.githubusercontent.com/3282350/111076628-787ed800-84c3-11eb-8e7c-186915c8b2ee.png)
![image](https://user-images.githubusercontent.com/3282350/111076694-bed43700-84c3-11eb-89ae-ad3790c8a652.png)|![image](https://user-images.githubusercontent.com/3282350/111076688-b8de5600-84c3-11eb-8651-4b6bd28c5638.png)
![image](https://user-images.githubusercontent.com/3282350/111076723-da3f4200-84c3-11eb-8665-67ecc6c67f32.png)|![image](https://user-images.githubusercontent.com/3282350/111076727-e1fee680-84c3-11eb-981c-e6bc25d37618.png)
