### PR TITLE
Nav: improve spacing when scrollbar is visible (#36)

### DIFF
--- a/src/components/Canvas/Canvas.vue
+++ b/src/components/Canvas/Canvas.vue
@@ -34,7 +34,7 @@
             </a>
           </nav>
         </div>
-        <div class="pl-4">
+        <div class="md:pl-4">
           <CanvasSection
             v-for="section in configTransformed"
             :key="section.title"

--- a/src/components/Canvas/Canvas.vue
+++ b/src/components/Canvas/Canvas.vue
@@ -16,7 +16,7 @@
             @input="$emit('toggle-dark-mode', $event)"
             label="Dark Mode"
           />
-          <nav class="w-56 pt-6 pb-12 px-3 h-full">
+          <nav class="pt-6 pr-20 pb-12 px-3 h-full">
             <a
               v-for="section in configTransformed"
               :key="section.title"
@@ -34,7 +34,7 @@
             </a>
           </nav>
         </div>
-        <div>
+        <div class="pl-4">
           <CanvasSection
             v-for="section in configTransformed"
             :key="section.title"


### PR DESCRIPTION
Resolves #36

Re-allocates the space between the nav and the main content so to let the main content breathe when the nav scrollbar is visible.

sidebar visible?|before|after
---|---|---
no|![image](https://user-images.githubusercontent.com/3282350/111076928-cea04b00-84c4-11eb-95d4-c3609c3e1a0a.png)|![image](https://user-images.githubusercontent.com/3282350/111076974-06a78e00-84c5-11eb-8ed8-789ff33d6d55.png)
yes|![image](https://user-images.githubusercontent.com/3282350/111076885-add7f580-84c4-11eb-9420-938c95645777.png)|![image](https://user-images.githubusercontent.com/3282350/111076966-fb546280-84c4-11eb-8b94-a4ed89ea8f6a.png)<br>