### PR TITLE
fix: avoid implicit dependency on tailwind

### DIFF
--- a/lib/tailwindConfigUtils.js
+++ b/lib/tailwindConfigUtils.js
@@ -4,9 +4,9 @@ const path = require('path')
  * This is required for running the config viewer directly with npx without
  * locally installing it
  */
-const tailwindResolveConfigPath = require.resolve('tailwindcss/resolveConfig', { paths: [process.cwd()] })
+const tailwindResolveConfigPath = require.resolve('tailwindcss/resolveConfig', { paths: [__dirname, process.cwd()] })
 const resolveTailwindConfig = require(tailwindResolveConfigPath)
-const flattenColorPalettePath = require.resolve('tailwindcss/lib/util/flattenColorPalette', { paths: [process.cwd()] })
+const flattenColorPalettePath = require.resolve('tailwindcss/lib/util/flattenColorPalette', { paths: [__dirname, process.cwd()] })
 const flattenColorPalette = require(flattenColorPalettePath).default
 
 const resolveConfigPath = configPath => path.resolve(process.cwd(), configPath)

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "portfinder": "^1.0.26",
     "replace-in-file": "^6.1.0"
   },
+  "peerDependencies": {
+    "tailwindcss": "1 || 2 || 2.0.1-compat"
+  },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.7.0",
     "@vue/cli-plugin-eslint": "^3.7.0",


### PR DESCRIPTION
Normally if `tailwind-config-viewer` is installed as a dependency, it is expected that `tailwind` is also installed alongside. But when it is used as a sub-dependency like in  `@nuxtjs/tailwindcss`, package manager might  _hoist_ it to top-level `node_modules` while `tailwind` dependency will not be hoisted and require cannot work anymore. To avoid such issues we should always explicitly define any imported dependency in `dependencies` or `peerDependencies`. (current ranges checked by https://semver.npmjs.com)

This PR also extends require path to first search for `tailwind` from package (default require behavior) and then fallback to cwd for supporting global install conditions.

Resolves https://github.com/nuxt-community/tailwindcss-module/issues/297