### PR TITLE
[FEAT] Add support for custom sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,41 @@ module.exports = {
   }
 }
 ```
+
+### customSections
+
+You can render custom sections within the viewer by setting the `customSections` option:
+
+```js
+module.exports = {
+  theme: {
+    // ...your Tailwind theme config
+    configViewer: {
+      customSections: [
+        {
+          title: 'Typography',
+          data: {
+            type: 'text',
+            sectionRows: [
+              {
+                utilityName: 'tw-h1',
+                utilityValues: ['tw-text-h1', 'tw-font-semibold', 'tw-tracking-widest', 'line-height: 3.2rem;'],
+                styles: {
+                  fontSize: '4.8rem',
+                  lineHeight: '7.2rem',
+                  fontWeight: 'bold'
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+```
+
 ## Usage Tips
 
 - `Shift+Click` on the Tailwind class names to copy multiple to your clipboard at once

--- a/src/components/Canvas/CanvasBlockLabel.vue
+++ b/src/components/Canvas/CanvasBlockLabel.vue
@@ -38,9 +38,12 @@
     >
       {{ prefixClassName(label) }}
     </div>
-    <div v-if="value" class="text-sm text-gray-700 dark:text-gray-500 break-words">
-      {{ displayValue }}
-    </div>
+
+    <slot name="value" v-bind:valueBoxClasses="valueBoxClasses">
+      <div v-if="value" :class="valueBoxClasses">
+        {{ displayValue }}
+      </div>
+    </slot>
   </div>
 </template>
 
@@ -75,6 +78,10 @@ export default {
   },
 
   computed: {
+    valueBoxClasses () {
+      return 'text-sm text-gray-700 dark:text-gray-500 break-words'
+    },
+
     copyValue () {
       return this.prefixedClassesToCopy.join(' ')
     },

--- a/src/components/Canvas/Sections/CustomSection.vue
+++ b/src/components/Canvas/Sections/CustomSection.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <div
+      v-for="row in rows"
+      :key="row.utilityName"
+    >
+      <div :style="row.styles">
+        <template v-if="data.type === 'text'">{{ data.typographyExample }}</template>
+      </div>
+
+      <CanvasBlockLabel
+        :label="row.utilityName"
+      >
+        <template #value="{ valueBoxClasses }">
+          <div :class="valueBoxClasses">
+            {{ row.utilityValue }}
+          </div>
+        </template>
+      </CanvasBlockLabel>
+    </div>
+  </div>
+</template>
+
+<script>
+import CanvasBlockLabel from '../CanvasBlockLabel'
+
+export default {
+  components: { CanvasBlockLabel },
+
+  props: {
+    data: {
+      type: Object,
+      required: true
+    },
+
+    config: {
+      type: Object,
+      required: true
+    }
+  },
+
+  computed: {
+    rows () {
+      return this.data.sectionRows.map((sectionRow) => ({
+        ...sectionRow,
+        utilityValue: sectionRow.utilityValues.join(', ')
+      }))
+    }
+  }
+}
+</script>

--- a/src/components/Canvas/themeComponentMapper.js
+++ b/src/components/Canvas/themeComponentMapper.js
@@ -1,8 +1,14 @@
+import defu from 'defu'
+import { makeDefaultCustomSection } from '@/defaultOptions'
+
 /**
  * Maps Canvas components to theme prop in TW config
  */
 export default function themeComponentMapper (theme) {
-  return [
+  const customSections = theme.configViewer.customSections
+    .map((customSection) => defu(customSection, makeDefaultCustomSection(theme)))
+
+  const sections = [
     {
       themeKey: 'backgroundColor',
       component: 'Colors',
@@ -132,4 +138,6 @@ export default function themeComponentMapper (theme) {
       data: theme.maxHeight
     }
   ].filter(({ themeKey }) => theme[themeKey])
+
+  return customSections.concat(sections)
 }

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -1,8 +1,20 @@
-export default {
+const defaultOptions = {
   theme: {
     configViewer: {
       baseFontSize: 16,
-      typographyExample: 'The quick brown fox jumped over the lazy dog.'
+      typographyExample: 'The quick brown fox jumped over the lazy dog.',
+      customSections: []
     }
   }
 }
+
+export const makeDefaultCustomSection = (theme) => ({
+  component: 'CustomSection',
+
+  data: {
+    type: 'text',
+    typographyExample: theme.configViewer.typographyExample
+  }
+})
+
+export default defaultOptions


### PR DESCRIPTION
First of all awesome work with this library! We are implementing Tailwind at my workplace and this config viewer is working it's way into the core of our UX documentation.

With that, we have created a custom plugin for creating typography utility classes, pretty basic stuff to combine utilities for font size, font weight, letter spacing & line heights into single utilities for our headings and body text.

This is currently documented within Storybook although it felt nicer to have this within the config viewer instead.

Here is where my proposed addition comes in, forgive me for any oversights I couldn't find any information regarding contribution guidelines for this project and this is my first open source contribution.

My idea is simple and flexible, allow custom sections to be rendered through a new configuration option, let me know what you think, or if you have any suggestions for a more appropriate approach.

Thanks!
