### PR TITLE
Support other values of fontSize

### DIFF
--- a/src/components/Canvas/Sections/FontSizes.vue
+++ b/src/components/Canvas/Sections/FontSizes.vue
@@ -6,15 +6,13 @@
     >
       <p
         class="mb-2 leading-none text-gray-900 dark:text-gray-500"
-        :style="{
-          fontSize: getFontSizeValue(value)
-        }"
+        :style="getFontSizeValue(value)"
       >
         {{ data.typographyExample }}
       </p>
       <CanvasBlockLabel
         :label="`text-${prop}`"
-        :value="getFontSizeValue(value)"
+        :value="getFontSizeString(value)"
       />
     </div>
   </div>
@@ -57,10 +55,18 @@ export default {
     getFontSizeValue (value) {
       // Tailwind 2.0 returns font size as array with size and line height
       if (Array.isArray(value)) {
-        return value[0]
+        return {
+          fontSize: value[0],
+          ...value[1]
+        }
       }
 
-      return value
+      return {
+        fontSize: value
+      }
+    },
+    getFontSizeString (value) {
+      return Object.values(this.getFontSizeValue(value)).join(', ')
     }
   }
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,5 +12,7 @@ export const remToPx = (rem, config) => {
 export const appendPxToRems = (rem, config) => {
   if (rem.search('rem') === -1) return rem
 
-  return `${rem} (${remToPx(rem, config)}px)`
+  return rem.replaceAll(/(\d|\.)*rem/g, (value) => {
+    return `${value} (${remToPx(value, config)}px)`
+  })
 }


### PR DESCRIPTION
As mentioned on #75, `fontSize` can accept default `fontWeight` amongst other values (since [v3.1.5](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.1.5)). with this PR, these values will be applied to `typographyExample` and visible on `CanvasBlockLabel`

![image](https://user-images.githubusercontent.com/14288838/205489108-3712fbb1-9c9a-4c90-847b-2d47bdb5325b.png)
