### PR TITLE
Add the letter s to default typography example

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ module.exports = {
   theme: {
     // ...your Tailwind theme config
     configViewer: {
-      typographyExample: 'The quick brown fox jumped over the lazy dog.'
+      typographyExample: 'The quick brown fox jumps over the lazy dog.'
     }
   }
 }

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -2,7 +2,7 @@ export default {
   theme: {
     configViewer: {
       baseFontSize: 16,
-      typographyExample: 'The quick brown fox jumped over the lazy dog.'
+      typographyExample: 'The quick brown fox jumps over the lazy dog.'
     }
   }
 }


### PR DESCRIPTION
The letter `s` wasn't in the typography example text, now it is.