### PR TITLE
refactor: remove console.log

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,6 @@ function createServer ({
   shouldOpen,
   routerPrefix = ''
 }) {
-  console.log('CONFIG PROVIDER: ', tailwindConfigProvider)
   const app = new Koa()
 
   const router = new Router({ prefix: routerPrefix })


### PR DESCRIPTION
In the latest release, a `console.log` was added that displays the following in a terminal:

```
CONFIG PROVIDER:  [Function (anonymous)]
```
