### PR TITLE
fix(themeReplacements): replace string

### DIFF
--- a/lib/tailwindConfigUtils.js
+++ b/lib/tailwindConfigUtils.js
@@ -55,6 +55,9 @@ const replaceWithOverrides = (theme) => {
 
 function findAndReplaceRecursively (target, find, replaceWith) {
   if (typeof target !== 'object') {
+    if (typeof target === 'string') {
+      return target.replace(find, replaceWith)
+    }
     if (target === find) return replaceWith
     return target
   }


### PR DESCRIPTION
### issue
`themeReplacements` is only working when string is fully matched
Sometimes it causes inconvenience.

inconvenience case:
```js
/** tailwind.config.js */
/** ... */
theme: {
  borderRadius: {
  lg: 'var(--radius)',
  md: 'calc(var(--radius) - 2px)',
  sm: 'calc(var(--radius) - 4px)',
  },
}

/** ... */
configViewer: {
  themeReplacements: {
    'var(--radius)': '0.2rem'
    'calc(var(--radius) - 2px)': 'calc(0.2rem - 2px)' // inconvenience
    'calc(var(--radius) - 4px)': 'calc(0.2rem - 4px)' // inconvenience
  }
}
```

### solve
`themeReplacements` will work when string matched partially.

### side effect
`themeReplacements` can work on unintended place which string is not fully matched.